### PR TITLE
Fixed error on user page.

### DIFF
--- a/modules/reservoir_ui/reservoir_ui.module
+++ b/modules/reservoir_ui/reservoir_ui.module
@@ -16,7 +16,7 @@ use Symfony\Component\HttpKernel\HttpKernelInterface;
 function reservoir_ui_help($route_name, \Drupal\Core\Routing\RouteMatchInterface $route_match) {
   switch ($route_name) {
     case 'entity.user.collection':
-      return '<p>' . t('A user represents a human. Users can log in to Reservoir if they have the <q>Content administrator</q> or <q>Client developer</q> <a href=":role">role</a>. Otherwise, they can only perform actions via a <a href=":client">Client</a>', [':role' => Url::fromRoute('entity.user_role.collection'), ':client' => Url::fromRoute('entity.oauth2_client.collection')]) . '</p>';
+      return '<p>' . t('A user represents a human. Users can log in to Reservoir if they have the <q>Content administrator</q> or <q>Client developer</q> <a href=":role">role</a>. Otherwise, they can only perform actions via a <a href=":client">Client</a>', [':role' => Url::fromRoute('entity.user_role.collection')->toString(), ':client' => Url::fromRoute('entity.oauth2_client.collection')->toString()]) . '</p>';
 
     // @todo override the default help from user.module, but hook_help() doesn't allow overriding this…
     //case 'user.admin_permissions':


### PR DESCRIPTION
When you visit the user page (admin/access/users) on a cold cache, you get the following error:

> Warning: strpos() expects parameter 1 to be string, object given in Drupal\Component\Utility\UrlHelper::stripDangerousProtocols() (line 352 of core/lib/Drupal/Component/Utility/UrlHelper.php)

This is because Url:fromRoute returns a URL object, not a string.