### PR TITLE
Update CORS config to allow GET and OPTIONS methods by default.

### DIFF
--- a/reservoir.services.yml
+++ b/reservoir.services.yml
@@ -1,8 +1,8 @@
 parameters:
   cors.config:
     enabled: true
-    allowedHeaders: []
-    allowedMethods: []
+    allowedHeaders: ['*']
+    allowedMethods: ['GET', 'OPTIONS']
     allowedOrigins: ['*']
     exposedHeaders: false
     maxAge: false


### PR DESCRIPTION
- Update CORS configuration
  - Allow `GET` and `OPTIONS` methods by default
  - Allow all headers by default. This should change along with `allowedOrigins` before deploying to a production environment.