### PR TITLE
Update project versions in composer.json to fix composer install

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,12 +13,11 @@
     ],
     "require": {
         "cweagans/composer-patches": "^1.5.0",
-        "composer/installers": "^1.0",
+        "composer/installers": "1.2.0",
         "drupal-composer/drupal-scaffold": "^2.0.0",
         "drupal/core": "^8.3.4",
         "webflo/drupal-core-strict": "^8.3.4",
-        "drupal/schemata": "1.x-dev#8325d172e1d6880aa24073f8f751ef089282cf9a",
-        "drupal/openapi": "1.x-dev#e8a82f87dbbb83dc89f9455f7a2e5ba6c6d2cdff",
+        "drupal/openapi": "1.0.0-alpha1",
         "drupal/jsonapi": "1.0.0",
         "drupal/simple_oauth": "2.0-rc2"
     },
@@ -33,9 +32,6 @@
             "drupal/core": {
                 "Fix toolbar active link handling": "https://www.drupal.org/files/issues/2885755-2-8.3.x.patch",
                 "field.storage.node.body belongs in 'standard' install profile, not in the 'node' module": "https://www.drupal.org/files/issues/2886861-2.patch"
-            },
-            "drupal/schemata": {
-                "Add entity type only schema routes for entity types with bundles": "https://www.drupal.org/files/issues/2870904-22.patch"
             },
             "drupal/simple_oauth": {
                 "simple_oauth cannot be installed in an install profile without also installing simple_oauth_extras": "https://www.drupal.org/files/issues/2883862-11.patch"

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
         "cweagans/composer-patches": "^1.5.0",
         "composer/installers": "^1.0",
         "drupal-composer/drupal-scaffold": "^2.0.0",
-        "drupal/core": "~8.3.4",
+        "drupal/core": "^8.3.4",
         "webflo/drupal-core-strict": "^8.3.4",
         "drupal/schemata": "1.x-dev#8325d172e1d6880aa24073f8f751ef089282cf9a",
         "drupal/openapi": "1.x-dev#e8a82f87dbbb83dc89f9455f7a2e5ba6c6d2cdff",


### PR DESCRIPTION
Updated

1. `"composer/installers": "1.2.0",` - fixes using 8.3.4 `"webflo/drupal-core-strict": "^8.3.4",`
2. `"drupal/openapi": "1.0.0-alpha1"` 
3. Removed `drupal/schemata` not need directly because openapi requires this selects the correct version.