### PR TITLE
Allow users to manage form display.

### DIFF
--- a/modules/reservoir_ui/src/Routing/ReservoirUiRouteSubscriber.php
+++ b/modules/reservoir_ui/src/Routing/ReservoirUiRouteSubscriber.php
@@ -80,9 +80,6 @@ class ReservoirUiRouteSubscriber implements EventSubscriberInterface  {
           $route->setPath('/admin/models/add');
           $route->setDefault('_title', 'Add content model');
           break;
-        case 'entity.entity_form_display.node.default':
-          $route->setRequirement('_access', 'FALSE');
-          break;
         case 'entity.entity_view_display.node.default':
           $route->setRequirement('_access', 'FALSE');
           break;


### PR DESCRIPTION
I don't understand why administrators aren't allowed to modify entity form displays. For instance, I think administrators should be able to arrange fields on the node add/edit forms used by content editors. This has nothing to do with the rendering of content (entity view display), which I agree should remain disabled.