### PR TITLE
Removed config dependency.

### DIFF
--- a/reservoir.info.yml
+++ b/reservoir.info.yml
@@ -30,7 +30,6 @@ dependencies:
   # Data: management.
   - ckeditor
   # Backend: management.
-  - config
   - dblog
   # Backend: UI.
   - reservoir_ui


### PR DESCRIPTION
The config module is [just a fancy UI](https://www.drupal.org/node/2877111) for the config import/export system, which most people probably don't need. It's a lot more practical to use drush commands for importing/exporting config, or something more integrated like BLT.

Leaving it enabled generates warnings on Acquia Cloud because the filesystem is not writeable, so it's best to keep it uninstalled.