### PR TITLE
Initial add of GraphQL. Turns on GraphQL Content and GraphQL Voyager.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,6 +19,7 @@
         "webflo/drupal-core-strict": "^8.3.4",
         "drupal/openapi": "1.0.0-alpha1",
         "drupal/jsonapi": "1.0.0",
+        "drupal/graphql": "3.0.0-alpha3",
         "drupal/simple_oauth": "2.0-rc2"
     },
     "require-dev": {

--- a/modules/reservoir_ui/reservoir_ui.info.yml
+++ b/modules/reservoir_ui/reservoir_ui.info.yml
@@ -8,3 +8,5 @@ required: true
 dependencies:
   - reservoir
   - jsonapi
+  - graphql
+  - graphql

--- a/modules/reservoir_ui/reservoir_ui.links.task.yml
+++ b/modules/reservoir_ui/reservoir_ui.links.task.yml
@@ -1,23 +1,23 @@
-reservoir_ui.api:
-  route_name: reservoir_ui.api
-  title: API
-  base_route: reservoir_ui.api
+reservoir_ui.json_api:
+  route_name: reservoir_ui.json_api
+  title: JSON API
+  base_route: reservoir_ui.json_api
 
-reservoir_ui.api.config:
-  route_name: reservoir_ui.api.config
+reservoir_ui.json_api.config:
+  route_name: reservoir_ui.json_api.config
   title: Configuration API
-  base_route: reservoir_ui.api
+  base_route: reservoir_ui.json_api
 
-reservoir_ui.api.authentication:
-  route_name: reservoir_ui.api.authentication
+reservoir_ui.json_api.authentication:
+  route_name: reservoir_ui.json_api.authentication
   title: Authentication
-  base_route: reservoir_ui.api
+  base_route: reservoir_ui.json_api
   weight: 90
 
 reservoir_ui.api.advanced:
   route_name: reservoir_ui.api.advanced
   title: Advanced
-  base_route: reservoir_ui.api
+  base_route: reservoir_ui.json_api
   weight: 100
 
 # @see field_ui.fields

--- a/modules/reservoir_ui/reservoir_ui.module
+++ b/modules/reservoir_ui/reservoir_ui.module
@@ -88,12 +88,12 @@ function reservoir_ui_toolbar_alter(&$items) {
   }
 
   if ($current_user->hasPermission('access openapi api docs')) {
-    $items['reservoir_api'] = array(
+    $items['reservoir_json_api'] = array(
       '#type' => 'toolbar_item',
       'tab' => array(
         '#type' => 'link',
-        '#title' => t('API'),
-        '#url' => Url::fromRoute('reservoir_ui.api'),
+        '#title' => t('JSON API'),
+        '#url' => Url::fromRoute('reservoir_ui.json_api'),
         '#options' => [
           'set_active_class' => TRUE,
         ],
@@ -105,7 +105,28 @@ function reservoir_ui_toolbar_alter(&$items) {
     );
   }
   else {
-    $items['reservoir_api'] = $empty_item_cacheability;
+    $items['reservoir_json_api'] = $empty_item_cacheability;
+  }
+
+  if ($current_user->hasPermission('use graphql voyager')) {
+    $items['reservoir_graphql'] = array(
+      '#type' => 'toolbar_item',
+      'tab' => array(
+        '#type' => 'link',
+        '#title' => t('GraphQL'),
+        '#url' => Url::fromRoute('graphql_voyager.voyager'),
+        '#options' => [
+          'set_active_class' => TRUE,
+        ],
+        '#attributes' => array(
+          'class' => array('toolbar-icon', 'toolbar-icon-system-modules-list'),
+        ),
+      ),
+      '#weight' => -30,
+    );
+  }
+  else {
+    $items['reservoir_graphql'] = $empty_item_cacheability;
   }
 
   if ($current_user->hasPermission('administer content types')) {

--- a/modules/reservoir_ui/reservoir_ui.routing.yml
+++ b/modules/reservoir_ui/reservoir_ui.routing.yml
@@ -6,8 +6,8 @@ reservoir_ui.home:
   requirements:
     _user_is_logged_in: 'TRUE'
 
-reservoir_ui.api:
-  path: '/admin/api'
+reservoir_ui.json_api:
+  path: '/admin/json-api-docs'
   defaults:
     _controller: '\Drupal\reservoir_ui\Controller\OpenApiDocs::generateDocs'
     entity_mode: 'content_entities'
@@ -15,8 +15,8 @@ reservoir_ui.api:
   requirements:
     _permission: 'access openapi api docs'
 
-reservoir_ui.api.config:
-  path: '/admin/api/config'
+reservoir_ui.json_api.config:
+  path: '/admin/json-api-docs/config'
   defaults:
     _controller: '\Drupal\reservoir_ui\Controller\OpenApiDocs::generateDocs'
     entity_mode: 'config_entities'
@@ -24,8 +24,8 @@ reservoir_ui.api.config:
   requirements:
     _permission: 'access openapi api docs'
 
-reservoir_ui.api.authentication:
-  path: '/admin/api/authentication'
+reservoir_ui.json_api.authentication:
+  path: '/admin/json-api-docs/authentication'
   defaults:
     _controller: '\Drupal\reservoir_ui\Controller\ApiAuthInfo::info'
   methods: [GET]
@@ -33,7 +33,7 @@ reservoir_ui.api.authentication:
     _permission: 'access openapi api docs'
 
 reservoir_ui.api.advanced:
-  path: '/admin/api/advanced'
+  path: '/admin/json-api-docs/advanced'
   defaults:
     _form: 'Drupal\reservoir_ui\Form\ApiAdvancedForm'
     _title: 'Advanced'

--- a/modules/reservoir_ui/src/Controller/Home.php
+++ b/modules/reservoir_ui/src/Controller/Home.php
@@ -44,7 +44,7 @@ class Home implements ContainerInjectionInterface {
 
     $api_docs_access = AccessResult::allowedIfHasPermission($this->currentUser, 'access openapi api docs');
     if ($api_docs_access->isAllowed()) {
-      $redirect_url = Url::fromRoute('reservoir_ui.api')->toString(TRUE);
+      $redirect_url = Url::fromRoute('reservoir_ui.json_api')->toString(TRUE);
       return (new CacheableRedirectResponse($redirect_url->getGeneratedUrl()))
         ->addCacheableDependency($redirect_url)
         ->addCacheableDependency($content_access)

--- a/modules/reservoir_ui/src/Form/ApiAdvancedForm.php
+++ b/modules/reservoir_ui/src/Form/ApiAdvancedForm.php
@@ -5,6 +5,11 @@ namespace Drupal\reservoir_ui\Form;
 use \Drupal\Core\Form\FormBase;
 use Drupal\Core\Form\FormStateInterface;
 
+/**
+ * Administrative form to enable different API modules
+ *
+ * @todo Make this form actually turn on API modules remove the form.
+ */
 class ApiAdvancedForm extends FormBase {
 
   /**
@@ -102,7 +107,8 @@ HTML;
     $form['graphql']['actions']['#type'] = 'actions';
     $form['graphql']['actions']['submit'] = [
       '#type' => 'submit',
-      '#value' => $this->t('Enable GraphQL'),
+      '#value' => $this->t('GraphQL already enabled!'),
+      '#disabled' => TRUE,
       '#button_type' => 'primary',
     ];
 

--- a/modules/reservoir_ui/src/Plugin/Derivative/BundleApiLocalTask.php
+++ b/modules/reservoir_ui/src/Plugin/Derivative/BundleApiLocalTask.php
@@ -49,7 +49,7 @@ class BundleApiLocalTask extends DeriverBase implements ContainerDeriverInterfac
     $this->derivatives["node_bundle_api"] = [
       'route_name' => 'reservoir_ui.entity.node_type.api',
       'weight' => 1,
-      'title' => $this->t('API'),
+      'title' => $this->t('JSON API'),
       'base_route' => $entity_type->get('field_ui_base_route'),
     ];
     return $this->derivatives;

--- a/reservoir.info.yml
+++ b/reservoir.info.yml
@@ -17,6 +17,8 @@ dependencies:
   - schemata
   - openapi
   - openapi_redoc
+  - graphql_content
+  - graphql_voyager
   # Data: modeling.
   - datetime
   - file


### PR DESCRIPTION
Add GraphQL support and turn on.

Right now this just turns on GraphQL Content and GraphQL Voyager. 

Remaining Tasks:

1. Determine if we should ship with configuration that presets "Exposed Content" as configured on  "admin/config/graphql/content"
2. Determine which entity types to expose.
3. Actually test connecting to it.

Remaining questions:

1. Do we turn on all GraphQL modules?
2. If we turn on all GraphQL module GraphQL Voyager page become very complicated?
3. Change the existing toolbar item from "API" to "JSON API" and added new "Graph QL" item that points to the GraphQL Voyager page. is this ok or do we want 1 top level "API" still?
4. Is the "Authenication" page work for both API modules. If so should be move under "Access Control" toolbar item?