### PR TITLE
Fix "composer create-project" no work

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
     ],
     "require": {
         "cweagans/composer-patches": "^1.5.0",
-        "composer/installers": "1.2.0",
+        "composer/installers": "^1.4.0",
         "drupal-composer/drupal-scaffold": "^2.0.0",
         "drupal/core": "^8.4.0",
         "webflo/drupal-core-strict": "^8.4.0",

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,6 @@
     ],
     "require": {
         "cweagans/composer-patches": "^1.5.0",
-        "composer/installers": "^1.4.0",
         "drupal-composer/drupal-scaffold": "^2.0.0",
         "drupal/core": "^8.4.0",
         "webflo/drupal-core-strict": "^8.4.0",


### PR DESCRIPTION
The version of `webflo/drupal-core-strict` used in this project depends on at least v1.4 of `composer/installers`. However, this project has hardcoded the `composer/installers` to use v1.2, which is causing Composer to derp out. This change updates `composer.json` so that `composer/installers` uses at least v1.4.